### PR TITLE
Introduce "trustedRedirects" flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,9 @@ Usage of mesos-exporter:
   -timeout duration
        	Master polling timeout (default 5s)
   -exportedTaskLabels
-        Comma-separated list of task labels to include in the task_labels metric       	
+        Comma-separated list of task labels to include in the task_labels metric
+  -trustedRedirects
+        Comma-separated list of trusted hosts (ip addresses, host names) where metrics requests can be redirected
 ```
 
 ## Docker 

--- a/common.go
+++ b/common.go
@@ -134,6 +134,7 @@ type httpClient struct {
 	http.Client
 	url  string
 	auth authInfo
+	trustedRedirects map[string]bool
 }
 
 type metricCollector struct {


### PR DESCRIPTION
This commit adds the possibility to specify a comma-separated string of trusted hosts and IP addresses with the `--trustedRedirects` flag.

Normally, request are automatically redirected to hosts but without the authorization header. With this fix, redirects from non-leading masters to the leading master will now set the authorization header when it is required. Additionally, redirects to non-trusted locations will be prohibited by default.